### PR TITLE
feat: add SFP module info to interface details; surface thermals via native widget

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ DISTDIR?=	${OPSDIR}/dist
 # libxml2 aarch64 package for cross-compilation sysroot (fmc links against it).
 # pkg.FreeBSD.org blocks directory listings, so we fetch by exact filename.
 # Update this when the FreeBSD ports tree bumps libxml2.
-LIBXML2_PKG?=	libxml2-2.15.2.pkg
+LIBXML2_PKG?=	libxml2-2.15.3.pkg
 LIBXML2_URL=	https://pkg.FreeBSD.org/FreeBSD:14:aarch64/latest/All/${LIBXML2_PKG}
 
 # Package version: derived from git tags (e.g., tag "26.1.2" + 3 commits = "26.1.2_3")
@@ -254,6 +254,9 @@ package: all
 	# OPNsense plugin files (hwmon dashboard widget)
 	cp -R ${OPSDIR}/plugins/hwmon/src/opnsense/ ${PKG_STAGEDIR}/usr/local/opnsense/
 	chmod 755 ${PKG_STAGEDIR}/usr/local/opnsense/scripts/hwmon/sensors.py
+	# OPNsense plugin files (SFP module info)
+	cp -R ${OPSDIR}/plugins/sfp/src/opnsense/ ${PKG_STAGEDIR}/usr/local/opnsense/
+	chmod 755 ${PKG_STAGEDIR}/usr/local/opnsense/scripts/interfaces/sfp_info.py
 	# CMM configd action (restart on interface reassignment)
 	install -m 644 ${PKG_CONFDIR}/actions_cmm.conf ${PKG_STAGEDIR}/usr/local/opnsense/service/conf/actions.d/
 	# Generate manifest with version

--- a/config/GATEWAY.conf
+++ b/config/GATEWAY.conf
@@ -82,7 +82,10 @@ arm_hook()
 		for p in "${PATCHDIR}"/*.patch; do
 			[ -f "${p}" ] || continue
 			echo ">>> Applying patch: $(basename ${p})"
-			patch -d "${STAGEDIR}/usr/local" -p1 < "${p}"
+			# Core src/ maps to /usr/local/ on the installed tree
+			# (src/opnsense -> /usr/local/opnsense, src/www -> /usr/local/www),
+			# so strip a/src/ (-p2). -t = batch: fail instead of prompting.
+			patch -d "${STAGEDIR}/usr/local" -p2 -t < "${p}"
 		done
 	fi
 

--- a/patches/interfaces-overview-sfp-info.patch
+++ b/patches/interfaces-overview-sfp-info.patch
@@ -1,0 +1,33 @@
+From: FOG_Yamato <contact@cybersnets.com>
+Subject: [PATCH] interfaces: show SFP module info in the details popup
+
+For SFP+ ports the platform exposes the module's decoded SFF-8472 data via
+`configctl sfp info <if>` (backed by dev.dtsec.N.sfp_eeprom). Inject the
+result as an `sfp` key in the interface details response; the existing
+details dialog auto-renders an object-valued key as a sub-table. The call
+returns {} for non-SFP interfaces, so it is safe to run unconditionally.
+
+Applied to the installed tree under /usr/local with: patch -p2
+---
+ src/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/OverviewController.php | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/OverviewController.php b/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/OverviewController.php
+--- a/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/OverviewController.php
++++ b/src/opnsense/mvc/app/controllers/OPNsense/Interfaces/Api/OverviewController.php
+@@ -290,6 +290,15 @@
+                     ];
+                 }
+ 
++                /* SFP module info for platform SFP+ ports (returns {} otherwise) */
++                $sfp = json_decode((new Backend())->configdpRun('sfp info', [$if]), true);
++                if (!empty($sfp) && is_array($sfp)) {
++                    $ifinfo['sfp'] = [
++                        'value' => $sfp,
++                        'translation' => gettext('SFP Module')
++                    ];
++                }
++
+                 $result['message'] = $ifinfo;
+             }
+         }

--- a/patches/thermal-sensors-friendly-names.patch
+++ b/patches/thermal-sensors-friendly-names.patch
@@ -1,0 +1,76 @@
+From: FOG_Yamato <contact@cybersnets.com>
+Subject: [PATCH] diagnostics: friendly names for SoC/board thermal sensors
+
+The LS1046A TMU and TMP431 board sensors expose readings under
+hw.temperature.* (e.g. hw.temperature.core-cluster). The Thermal Sensors
+dashboard widget labels each bar as "${type_translated} ${device_seq}";
+these sensors fall through to "Other" with a numeric sequence of 0 (no
+digits in the name), so every sensor renders as the identical "Other 0".
+
+Map hw.temperature.* leaves to friendly labels and blank the numeric
+sequence so the widget shows just the name (e.g. "Core Cluster"). Sensor
+selection still keys off the unique device field.
+
+Applies to opnsense/core stable/26.1. Verify on the build server with:
+    git -C /usr/core apply --check patches/thermal-sensors-friendly-names.patch
+---
+ .../OPNsense/Diagnostics/Api/SystemController.php  | 25 +++++++++++++++++++++-
+ 1 file changed, 24 insertions(+), 1 deletion(-)
+
+diff --git a/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/SystemController.php b/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/SystemController.php
+--- a/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/SystemController.php
++++ b/src/opnsense/mvc/app/controllers/OPNsense/Diagnostics/Api/SystemController.php
+@@ -233,26 +233,49 @@ class SystemController extends ApiControllerBase
+         /* read temperatures individually from previously derived sensors */
+         $sensors = explode("\n", $backend->configdRun('system sensors'));
+         $temps = json_decode($backend->configdpRun('system sysctl values', join(',', $sensors)), true);
+
++        /* friendly labels for SoC/board thermal sensors (hw.temperature.*) */
++        $soc_labels = [
++            'core-cluster' => 'Core Cluster',
++            'ddr-controller' => 'DDR Controller',
++            'fman' => 'FMan',
++            'sec' => 'SEC',
++            'serdes' => 'SerDes',
++            'cpu-board-local' => 'CPU Ambient',
++            'cpu-board-remote' => 'CPU Die',
++            'network-board-local' => 'Board Ambient',
++            'network-board-remote' => 'Network Die',
++        ];
++
+         foreach ($temps as $name => $value) {
+             $tempItem = [];
+             $tempItem['device'] = $name;
+             $tempItem['device_seq'] = (int)filter_var($tempItem['device'], FILTER_SANITIZE_NUMBER_INT);
+             $tempItem['temperature'] = trim(str_replace('C', '', $value));
+             $tempItem['type_translated'] = gettext('Other');
+             $tempItem['type'] = 'other';
+
+             /* try to categorize a few of the readings just for labels */
+-            if (str_starts_with($tempItem['device'], 'hw.acpi.')) {
++            if (str_starts_with($tempItem['device'], 'hw.temperature.')) {
++                $leaf = substr($tempItem['device'], strlen('hw.temperature.'));
++                if (isset($soc_labels[$leaf])) {
++                    $tempItem['type_translated'] = $soc_labels[$leaf];
++                } else {
++                    $tempItem['type_translated'] = ucwords(str_replace(['-', '_'], ' ', $leaf));
++                }
++                $tempItem['type'] = 'soc';
++                /* blank the numeric sequence so the widget shows just the name */
++                $tempItem['device_seq'] = '';
++            } elseif (str_starts_with($tempItem['device'], 'hw.acpi.')) {
+                 $tempItem['type_translated'] = gettext('Zone');
+                 $tempItem['type'] = 'zone';
+             } elseif (str_starts_with($tempItem['device'], 'dev.amdtemp.')) {
+                 $tempItem['type_translated'] = gettext('AMD');
+                 $tempItem['type'] = 'amd';
+             } elseif (str_starts_with($tempItem['device'], 'dev.pchtherm.')) {
+                 $tempItem['type_translated'] = gettext('Platform');
+                 $tempItem['type'] = 'platform';
+             } elseif (str_starts_with($tempItem['device'], 'dev.cpu.')) {
+                 $tempItem['type_translated'] = gettext('CPU');
+                 $tempItem['type'] = 'cpu';
+             }
+
+             $result[] = $tempItem;
+         }

--- a/pkg/plist
+++ b/pkg/plist
@@ -29,6 +29,8 @@
 /usr/local/opnsense/scripts/hwmon/sensors.py
 /usr/local/opnsense/service/conf/actions.d/actions_hwmon.conf
 /usr/local/opnsense/service/conf/actions.d/actions_cmm.conf
+/usr/local/opnsense/scripts/interfaces/sfp_info.py
+/usr/local/opnsense/service/conf/actions.d/actions_sfp.conf
 /usr/local/opnsense/mvc/app/controllers/OPNsense/Hwmon/Api/SensorsController.php
 /usr/local/opnsense/mvc/app/models/OPNsense/Hwmon/ACL/ACL.xml
 /usr/local/opnsense/www/js/widgets/Hwmon.js

--- a/plugins/hwmon/src/opnsense/mvc/app/controllers/OPNsense/Hwmon/Api/SensorsController.php
+++ b/plugins/hwmon/src/opnsense/mvc/app/controllers/OPNsense/Hwmon/Api/SensorsController.php
@@ -12,7 +12,7 @@ class SensorsController extends ApiControllerBase
         $backend = new Backend();
         $data = json_decode($backend->configdRun('hwmon sensors'), true);
         if (!is_array($data)) {
-            return ['power' => [], 'fans' => [], 'temperatures' => []];
+            return ['power' => [], 'fans' => []];
         }
         return $data;
     }

--- a/plugins/hwmon/src/opnsense/scripts/hwmon/sensors.py
+++ b/plugins/hwmon/src/opnsense/scripts/hwmon/sensors.py
@@ -2,8 +2,8 @@
 
 """
 Hardware sensor reader for Mono Gateway dashboard widget.
-Discovers and reads INA2xx power monitors, EMC2302 fan controllers,
-and TMU temperature sensors via sysctl.
+Discovers and reads INA2xx power monitors and EMC2302 fan controllers
+via sysctl.
 """
 
 import json
@@ -95,8 +95,10 @@ def parse_fans(raw):
             # Skip fans with 0 RPM (stalled or not connected)
             if rpm == 0:
                 continue
+            # The board has a single SoC fan on fan0; give it a friendly name.
+            label = 'SoC Fan' if fan_id == 'fan0' else fan_id
             fans.append({
-                'label': fan_id,
+                'label': label,
                 'rpm': rpm,
                 'pwm': pwm_pct,
                 'fault': fault != 0,
@@ -104,37 +106,13 @@ def parse_fans(raw):
     return fans
 
 
-def parse_temperatures(raw):
-    """Parse hw.temperature.* into temperature list."""
-    temps = []
-    for key, val in sorted(raw.items()):
-        if not key.startswith('hw.temperature.'):
-            continue
-        name = key.replace('hw.temperature.', '')
-        # Value is like "47.0C"
-        temp_str = val.rstrip('C').strip()
-        try:
-            temp = float(temp_str)
-        except ValueError:
-            continue
-        # Pretty-print the name: core-cluster -> Core Cluster
-        label = name.replace('-', ' ').replace('_', ' ').title()
-        temps.append({
-            'label': label,
-            'value': temp,
-        })
-    return temps
-
-
 if __name__ == '__main__':
     power_raw = sysctl_tree('dev.ina2xx')
     fan_raw = sysctl_tree('dev.emc2302')
-    temp_raw = sysctl_tree('hw.temperature')
 
     result = {
         'power': parse_power(power_raw),
         'fans': parse_fans(fan_raw),
-        'temperatures': parse_temperatures(temp_raw),
     }
 
     print(json.dumps(result))

--- a/plugins/hwmon/src/opnsense/www/js/widgets/Hwmon.js
+++ b/plugins/hwmon/src/opnsense/www/js/widgets/Hwmon.js
@@ -53,24 +53,16 @@ export default class Hwmon extends BaseTableWidget {
             headerPosition: 'left',
         });
 
-        let $tempHeader = $(`<div class="hwmon-section" id="hwmon-temp-section">
-            <b><i class="fa fa-thermometer-half"></i> ${this.translations.temperatures}</b>
-        </div>`);
-        let $tempTable = this.createTable('hwmon-temps', {
-            headerPosition: 'left',
-        });
-
-        $container.append($powerHeader, $powerTable, $fanHeader, $fanTable, $tempHeader, $tempTable);
+        $container.append($powerHeader, $powerTable, $fanHeader, $fanTable);
         return $container;
     }
 
     async onWidgetTick() {
         const data = await this.ajaxCall('/api/hwmon/sensors/status');
 
-        if (!data || (!data.power?.length && !data.fans?.length && !data.temperatures?.length)) {
+        if (!data || (!data.power?.length && !data.fans?.length)) {
             $('#hwmon-power-section').hide();
             $('#hwmon-fan-section').hide();
-            $('#hwmon-temp-section').hide();
             $('#hwmon-power').html(`<div style="margin: 1em;">${this.translations.nosensors}</div>`);
             return;
         }
@@ -105,22 +97,6 @@ export default class Hwmon extends BaseTableWidget {
             super.updateTable('hwmon-fans', fanRows);
         } else {
             $('#hwmon-fan-section').hide();
-        }
-
-        // Temperatures
-        if (data.temperatures?.length) {
-            $('#hwmon-temp-section').show();
-            let tempRows = [];
-            data.temperatures.forEach(t => {
-                let color = t.value >= 80 ? 'text-danger' : (t.value >= 70 ? 'text-warning' : '');
-                let display = color
-                    ? `<span class="${color}">${t.value.toFixed(1)}&deg;C</span>`
-                    : `${t.value.toFixed(1)}&deg;C`;
-                tempRows.push([t.label, display]);
-            });
-            super.updateTable('hwmon-temps', tempRows);
-        } else {
-            $('#hwmon-temp-section').hide();
         }
     }
 }

--- a/plugins/hwmon/src/opnsense/www/js/widgets/Metadata/Hwmon.xml
+++ b/plugins/hwmon/src/opnsense/www/js/widgets/Metadata/Hwmon.xml
@@ -8,7 +8,6 @@
             <title>Hardware Monitor</title>
             <power>Power</power>
             <fans>Fans</fans>
-            <temperatures>Temperatures</temperatures>
             <nosensors>No hardware sensors detected.</nosensors>
         </translations>
     </hwmon>

--- a/plugins/sfp/src/opnsense/scripts/interfaces/sfp_info.py
+++ b/plugins/sfp/src/opnsense/scripts/interfaces/sfp_info.py
@@ -1,0 +1,214 @@
+#!/usr/local/bin/python3
+
+"""
+SFP/SFP+ module information reader for the Mono Gateway.
+
+Reads the raw module EEPROM (SFF-8472 A0h + A2h pages) exported by the dtsec
+driver via `dev.dtsec.<unit>.sfp_eeprom` (a hex string) and decodes it into a
+flat {label: value} dict for the interface details popup.
+"""
+
+import json
+import math
+import re
+import struct
+import subprocess
+import sys
+
+
+HEX_RE = re.compile(r'^[0-9a-fA-F]*$')
+
+CONNECTORS = {
+    0x00: "Unknown",
+    0x01: "SC",
+    0x07: "LC",
+    0x0B: "Optical pigtail",
+    0x0C: "MPO 1x12",
+    0x21: "Copper pigtail",
+    0x22: "RJ45",
+    0x23: "No separable connector",
+}
+
+_ALARM_112 = [
+    (0x80, "Temp high"), (0x40, "Temp low"),
+    (0x20, "Vcc high"), (0x10, "Vcc low"),
+    (0x08, "TX bias high"), (0x04, "TX bias low"),
+    (0x02, "TX power high"), (0x01, "TX power low"),
+]
+_ALARM_113 = [
+    (0x80, "RX power high"), (0x40, "RX power low"),
+]
+
+
+def _ascii(b):
+    return bytes(b).decode("ascii", "replace").strip()
+
+
+def _u16(b, off):
+    return (b[off] << 8) | b[off + 1]
+
+
+def _s16(b, off):
+    v = _u16(b, off)
+    return v - 0x10000 if (v & 0x8000) else v
+
+
+def _f32(b, off):
+    return struct.unpack(">f", bytes(b[off:off + 4]))[0]
+
+
+def _slope(b, off):
+    return b[off] + b[off + 1] / 256.0
+
+
+def _dbm(mw):
+    if mw <= 0:
+        return "-inf"
+    return "%.2f dBm" % (10.0 * math.log10(mw))
+
+
+def media_type(a0):
+    """Best-effort media/compliance string from connector + compliance codes."""
+    conn = a0[2]
+    codes = []
+    eth10g = a0[3]
+    if eth10g & 0x10:
+        codes.append("10GBASE-SR")
+    if eth10g & 0x20:
+        codes.append("10GBASE-LR")
+    if eth10g & 0x40:
+        codes.append("10GBASE-LRM")
+    if eth10g & 0x80:
+        codes.append("10GBASE-ER")
+    eth1g = a0[6]
+    if eth1g & 0x01:
+        codes.append("1000BASE-SX")
+    if eth1g & 0x02:
+        codes.append("1000BASE-LX")
+    if eth1g & 0x08:
+        codes.append("1000BASE-T")
+    cable = a0[8]  # SFP+ cable technology
+    if cable & 0x04:
+        codes.append("10GBASE-CR (passive)")
+    if cable & 0x08:
+        codes.append("10GBASE-CR (active)")
+    if not codes and conn == 0x22:
+        codes.append("10GBASE-T")
+    return ", ".join(codes) if codes else "Unknown"
+
+
+def decode_alarms(a2):
+    active = []
+    for bit, label in _ALARM_112:
+        if a2[112] & bit:
+            active.append(label)
+    for bit, label in _ALARM_113:
+        if a2[113] & bit:
+            active.append(label)
+    return ", ".join(active) if active else "none"
+
+
+def decode_ddm(a0, a2):
+    """Return DDM (diagnostics) fields if implemented, else {}."""
+    dmt = a0[92]
+    if not (dmt & 0x40):           # bit6: DDM implemented
+        return {}
+    external = bool(dmt & 0x10)    # bit4: externally calibrated
+
+    t_raw = _s16(a2, 96)
+    v_raw = _u16(a2, 98)
+    bias_raw = _u16(a2, 100)
+    txp_raw = _u16(a2, 102)
+    rxp_raw = _u16(a2, 104)
+
+    if external:
+        t_cnt = _slope(a2, 84) * t_raw + _s16(a2, 86)
+        v_cnt = _slope(a2, 88) * v_raw + _s16(a2, 90)
+        bias_cnt = _slope(a2, 76) * bias_raw + _s16(a2, 78)
+        txp_cnt = _slope(a2, 80) * txp_raw + _s16(a2, 82)
+        c4 = _f32(a2, 56); c3 = _f32(a2, 60); c2 = _f32(a2, 64)
+        c1 = _f32(a2, 68); c0 = _f32(a2, 72)
+        rxp_cnt = (c4 * rxp_raw ** 4 + c3 * rxp_raw ** 3 +
+                   c2 * rxp_raw ** 2 + c1 * rxp_raw + c0)
+    else:
+        t_cnt, v_cnt, bias_cnt, txp_cnt, rxp_cnt = \
+            t_raw, v_raw, bias_raw, txp_raw, rxp_raw
+
+    temp_c = t_cnt / 256.0
+    vcc_v = v_cnt * 0.0001          # LSB 100 uV
+    bias_ma = bias_cnt * 0.002      # LSB 2 uA
+    txp_mw = txp_cnt * 0.0001       # LSB 0.1 uW
+    rxp_mw = rxp_cnt * 0.0001       # LSB 0.1 uW
+
+    return {
+        "Temperature": "%.1f °C" % temp_c,
+        "Supply Voltage": "%.2f V" % vcc_v,
+        "TX Bias": "%.2f mA" % bias_ma,
+        "TX Power": _dbm(txp_mw),
+        "RX Power": _dbm(rxp_mw),
+        "Alarms": decode_alarms(a2),
+    }
+
+
+def decode(a0, a2):
+    """Decode A0h+A2h byte arrays into a flat ordered {label: value} dict."""
+    if len(a0) < 96 or a0[0] == 0x00:
+        return {}
+    info = {}
+    info["Type"] = media_type(a0)
+    info["Connector"] = CONNECTORS.get(a0[2], "0x%02x" % a0[2])
+    info["Vendor"] = _ascii(a0[20:36])
+    info["OUI"] = "%02x:%02x:%02x" % (a0[37], a0[38], a0[39])
+    info["Part Number"] = _ascii(a0[40:56])
+    info["Revision"] = _ascii(a0[56:60])
+    info["Serial Number"] = _ascii(a0[68:84])
+    info["Date Code"] = _ascii(a0[84:92])
+    bitrate = a0[12]
+    if bitrate:
+        info["Nominal Bitrate"] = "%d Mbps" % (bitrate * 100)
+    wl = _u16(a0, 60)
+    if a0[2] in (0x01, 0x07, 0x0B, 0x0C) and wl:  # optical connectors only
+        info["Wavelength"] = "%d nm" % wl
+    info.update(decode_ddm(a0, a2))
+    return {k: v for k, v in info.items() if v not in ("", None)}
+
+
+def _hex_to_bytes(s):
+    s = (s or "").strip()
+    if not s or not HEX_RE.match(s):
+        return None
+    try:
+        return bytearray.fromhex(s)
+    except ValueError:
+        return None
+
+
+def read_eeprom(ifname):
+    """Return (a0, a2) bytearrays for the interface, or None if unavailable."""
+    m = re.fullmatch(r"dtsec(\d+)", ifname or "")
+    if not m:
+        return None
+    oid = "dev.dtsec.%s.sfp_eeprom" % m.group(1)
+    try:
+        out = subprocess.run(
+            ["/sbin/sysctl", "-nq", oid],
+            capture_output=True, text=True
+        ).stdout.strip()
+    except OSError:
+        return None
+    raw = _hex_to_bytes(out)
+    if raw is None or len(raw) < 512:
+        return None
+    return raw[:256], raw[256:512]
+
+
+def info_for(ifname):
+    pages = read_eeprom(ifname)
+    if pages is None:
+        return {}
+    return decode(pages[0], pages[1])
+
+
+if __name__ == "__main__":
+    ifname = sys.argv[1] if len(sys.argv) > 1 else ""
+    print(json.dumps(info_for(ifname)))

--- a/plugins/sfp/src/opnsense/scripts/interfaces/sfp_info.py
+++ b/plugins/sfp/src/opnsense/scripts/interfaces/sfp_info.py
@@ -70,6 +70,25 @@ def _dbm(mw):
 def media_type(a0):
     """Best-effort media/compliance string from connector + compliance codes."""
     conn = a0[2]
+    # Copper RJ45 modules embed a PHY and report their real link type over MDIO,
+    # not in the SFF optical/cable compliance bytes — which they routinely set
+    # spuriously (e.g. FS SFP-10G-T sets the passive-DAC bit, Ubiquiti
+    # UACC-CM-RJ45-MG sets the 10GBASE-SR bit). Classify these by the declared
+    # max signaling rate (byte 12, units of 100 Mbps) instead; the PHY
+    # negotiates the actual mode (2.5G/5G/...) and the kernel logs it separately.
+    if conn == 0x22:               # RJ45
+        rate = a0[12] * 100        # Mbps; module's maximum rate
+        if rate >= 10000:
+            return "10GBASE-T"
+        if rate >= 5000:
+            return "5GBASE-T"
+        if rate >= 2500:
+            return "2.5GBASE-T"
+        if rate >= 1000:
+            return "1000BASE-T"
+        if rate >= 100:
+            return "100BASE-TX"
+        return "10GBASE-T"         # rate undeclared: default to the cage's max
     codes = []
     eth10g = a0[3]
     if eth10g & 0x10:
@@ -92,8 +111,6 @@ def media_type(a0):
         codes.append("10GBASE-CR (passive)")
     if cable & 0x08:
         codes.append("10GBASE-CR (active)")
-    if not codes and conn == 0x22:
-        codes.append("10GBASE-T")
     return ", ".join(codes) if codes else "Unknown"
 
 
@@ -202,11 +219,36 @@ def read_eeprom(ifname):
     return raw[:256], raw[256:512]
 
 
+def read_phy_modes(ifname):
+    """Supported copper PHY rates (e.g. "1G, 2.5G, 5G, 10G"), or "" if N/A.
+
+    Sourced from the dtsec driver, which reads the module PHY's MDIO ability
+    registers — the SFF EEPROM cannot enumerate negotiable rates. Empty for
+    fiber/DAC modules and 10G-only copper without multigig support.
+    """
+    m = re.fullmatch(r"dtsec(\d+)", ifname or "")
+    if not m:
+        return ""
+    oid = "dev.dtsec.%s.sfp_phy_modes" % m.group(1)
+    try:
+        return subprocess.run(
+            ["/sbin/sysctl", "-nq", oid],
+            capture_output=True, text=True
+        ).stdout.strip()
+    except OSError:
+        return ""
+
+
 def info_for(ifname):
     pages = read_eeprom(ifname)
     if pages is None:
         return {}
-    return decode(pages[0], pages[1])
+    info = decode(pages[0], pages[1])
+    if info:
+        modes = read_phy_modes(ifname)
+        if modes:
+            info["Supported Rates"] = modes
+    return info
 
 
 if __name__ == "__main__":

--- a/plugins/sfp/src/opnsense/service/conf/actions.d/actions_sfp.conf
+++ b/plugins/sfp/src/opnsense/service/conf/actions.d/actions_sfp.conf
@@ -1,0 +1,5 @@
+[info]
+command:/usr/local/opnsense/scripts/interfaces/sfp_info.py
+parameters:%s
+type:script_output
+message:Read SFP module info for %s


### PR DESCRIPTION
## Summary

Adds SFP+ module information to the interface details popup and reworks how board/SoC temperatures are presented — moving them off the custom hwmon dashboard widget and onto OPNsense's native Diagnostics → Thermal Sensors widget with proper labels.

## Changes

### SFP module info
- **New `plugins/sfp/` plugin** — `sfp_info.py` decodes the SFF-8472 A0h/A2h EEPROM pages exported by the dtsec driver (`dev.dtsec.<unit>.sfp_eeprom`) into a flat `{label: value}` dict, exposed via a new `actions_sfp.conf` configd action (`configctl sfp info <if>`).
- **`patches/interfaces-overview-sfp-info.patch`** — injects the decoded data as an `sfp` key in the interface details response. The existing details dialog auto-renders an object-valued key as a sub-table. Returns `{}` for non-SFP ports, so it runs unconditionally.
- Wired the plugin into the package (`Makefile`, `pkg/plist`).

### Thermal sensors
- Removed temperature reading from the hwmon dashboard widget (`sensors.py`, `Hwmon.js`, `SensorsController.php`, `Metadata/Hwmon.xml`) — it duplicated the native Thermal Sensors widget.
- **`patches/thermal-sensors-friendly-names.patch`** — maps `hw.temperature.*` leaves (LS1046A TMU, TMP431) to friendly labels (e.g. `core-cluster` → "Core Cluster") and blanks the numeric sequence. Previously every SoC sensor fell through to the identical "Other 0" label.
- Gave the single SoC fan (`fan0`) a friendly "SoC Fan" label.

### Build / packaging
- `GATEWAY.conf`: apply core patches with `patch -p2 -t` instead of `-p1`. Core `src/` maps to `/usr/local/` on the installed tree, so we strip `a/src/`; `-t` runs in batch mode (fail instead of prompting).
- Bumped libxml2 cross-compile package to `2.15.3`.