### PR TITLE
Fix/mono gateway freebsd15.1 build breaks

### DIFF
--- a/config/GATEWAY.conf
+++ b/config/GATEWAY.conf
@@ -19,31 +19,44 @@ DEPSDIR="${DEPSDIR:-/usr/deps}"
 MONO_GW_DEPS="${MONO_GW_DEPS:-${DEPSDIR}/dist}"
 
 arm_install_uboot()
-{
-	# We need kernel.img and DTB on the FAT boot partition for U-Boot to
-	# load via booti.
+  {
+      # We need kernel.img and DTB on the FAT boot partition for U-Boot to
+      # load via booti.
 
-	aarch64-unknown-freebsd15.0-objcopy -O binary \
+      # Produce a U-Boot booti-compatible Image (header + flat binary),
+      # matching FreeBSD's own sys/conf/Makefile.arm64 recipe for                              
+      # ${KERNEL_KO}.bin -- objcopy alone only produces a flat binary,
+      # which lacks the Linux ARM64 Image magic header booti requires.
+      aarch64-unknown-freebsd15.0-objcopy --wildcard \
+          --strip-symbol='$[adtx]*' --output-target=binary \
           ${STAGEDIR}/boot/kernel/kernel \
-          ${STAGEDIR}/boot/kernel/kernel.bin
+          ${STAGEDIR}/boot/kernel/kernel.bin.temp
 
-	# Move kernel
-	mv ${STAGEDIR}/boot/kernel/kernel.bin \
-	    ${STAGEDIR}/boot/msdos/kernel.img
+      { aarch64-unknown-freebsd15.0-nm ${STAGEDIR}/boot/kernel/kernel | \
+          LC_ALL=C awk -f ${SRCDIR}/sys/tools/arm_kernel_boothdr.awk \
+              -v hdrtype=v8booti && \
+          cat ${STAGEDIR}/boot/kernel/kernel.bin.temp; \
+      } > ${STAGEDIR}/boot/kernel/kernel.bin
 
-	# Copy device tree binary
-	mkdir -p ${STAGEDIR}/boot/msdos/dtb
-	cp ${STAGEDIR}/boot/dtb/freescale/mono-gateway-dk.dtb \
-	    ${STAGEDIR}/boot/msdos/dtb/
+      rm ${STAGEDIR}/boot/kernel/kernel.bin.temp
+  
+      # Move kernel
+      mv ${STAGEDIR}/boot/kernel/kernel.bin \
+          ${STAGEDIR}/boot/msdos/kernel.img
 
-	# rc.conf.local must be written here (not in arm_hook) because
-	# setup_xbase() deletes rc.conf.local after arm_hook runs.
-	local MONO_GW_RCD="${DEPSDIR}/rc.d"
-	if [ -f "${MONO_GW_RCD}/rc.conf.local" ]; then
-		cat "${MONO_GW_RCD}/rc.conf.local" >> \
-		    "${STAGEDIR}/etc/rc.conf.local"
-	fi
-}
+      # Copy device tree binary
+      mkdir -p ${STAGEDIR}/boot/msdos/dtb
+      cp ${STAGEDIR}/boot/dtb/freescale/mono-gateway-dk.dtb \
+          ${STAGEDIR}/boot/msdos/dtb/
+
+      # rc.conf.local must be written here (not in arm_hook) because
+      # setup_xbase() deletes rc.conf.local after arm_hook runs.
+      local MONO_GW_RCD="${DEPSDIR}/rc.d"
+      if [ -f "${MONO_GW_RCD}/rc.conf.local" ]; then
+          cat "${MONO_GW_RCD}/rc.conf.local" >> \
+              "${STAGEDIR}/etc/rc.conf.local"
+      fi
+  }
 
 arm_hook()
 {

--- a/config/GATEWAY.conf
+++ b/config/GATEWAY.conf
@@ -23,6 +23,10 @@ arm_install_uboot()
 	# We need kernel.img and DTB on the FAT boot partition for U-Boot to
 	# load via booti.
 
+	aarch64-unknown-freebsd15.0-objcopy -O binary \
+          ${STAGEDIR}/boot/kernel/kernel \
+          ${STAGEDIR}/boot/kernel/kernel.bin
+
 	# Move kernel
 	mv ${STAGEDIR}/boot/kernel/kernel.bin \
 	    ${STAGEDIR}/boot/msdos/kernel.img

--- a/drivers/caam/caam.c
+++ b/drivers/caam/caam.c
@@ -751,7 +751,7 @@ caam_alloc_resource(device_t bus, device_t child, int type, int *rid,
  * The child gets its own bus handle pointing into our VA space.
  */
 static int
-caam_activate_resource(device_t bus, device_t child, int type, int rid, struct resource *res)
+caam_activate_resource(device_t bus, device_t child, struct resource *res)
 {
 	struct caam_softc *sc;
 	bus_space_handle_t bh;
@@ -761,11 +761,11 @@ caam_activate_resource(device_t bus, device_t child, int type, int rid, struct r
 	sc = device_get_softc(bus);
 
 	if (rman_get_type(res) != SYS_RES_MEMORY)
-		return (bus_generic_activate_resource(bus, child, type, rid, res));
+		return (bus_generic_activate_resource(bus, child, res));
 
 	/* Verify the resource belongs to our rman */
 	if (rman_is_region_manager(res, &sc->sc_mem_rman) == 0)
-		return (bus_generic_activate_resource(bus, child, type, rid, res));
+		return (bus_generic_activate_resource(bus, child, res));
 
 	bt = rman_get_bustag(sc->sc_rres);
 	rv = bus_space_subregion(bt, rman_get_bushandle(sc->sc_rres),
@@ -788,7 +788,7 @@ caam_activate_resource(device_t bus, device_t child, int type, int rid, struct r
  * Just clear the RF_ACTIVE flag.
  */
 static int
-caam_deactivate_resource(device_t bus, device_t child, int type, int rid, struct resource *res)
+caam_deactivate_resource(device_t bus, device_t child, struct resource *res)
 {
 	struct caam_softc *sc;
 
@@ -796,7 +796,7 @@ caam_deactivate_resource(device_t bus, device_t child, int type, int rid, struct
 
 	if (rman_get_type(res) != SYS_RES_MEMORY ||
 	    rman_is_region_manager(res, &sc->sc_mem_rman) == 0)
-		return (bus_generic_deactivate_resource(bus, child, type, rid, res));
+		return (bus_generic_deactivate_resource(bus, child, res));
 
 	return (rman_deactivate_resource(res));
 }
@@ -805,7 +805,7 @@ caam_deactivate_resource(device_t bus, device_t child, int type, int rid, struct
  * Bus method: release a child's resource.
  */
 static int
-caam_release_resource(device_t bus, device_t child, int type, int rid, struct resource *res)
+caam_release_resource(device_t bus, device_t child, struct resource *res)
 {
 	struct caam_softc *sc;
 	struct resource_list_entry *rle;
@@ -815,10 +815,10 @@ caam_release_resource(device_t bus, device_t child, int type, int rid, struct re
 
 	if (rman_get_type(res) != SYS_RES_MEMORY ||
 	    rman_is_region_manager(res, &sc->sc_mem_rman) == 0)
-		return (bus_generic_rl_release_resource(bus, child, type, rid, res));
+		return (bus_generic_rl_release_resource(bus, child, res));
 
 	if ((rman_get_flags(res) & RF_ACTIVE) != 0) {
-		rv = bus_deactivate_resource(child, type, rid, res);
+		rv = bus_deactivate_resource(child, res);
 		if (rv != 0)
 			return (rv);
 	}


### PR DESCRIPTION
Two fixes needed to get a working from-source build (`arm-5G`) against current FreeBSD 15.1/stable-26.7 source. Not hardware-specific — these affect anyone building from source, on any host architecture, not just the aarch64-native path used here.
  
  ## 1. caam.c — bus resource-management API drift
  FreeBSD's bus_activate_resource/bus_deactivate_resource/bus_release_resource
  dropped the type/rid params upstream. Updated the 3 CAAM driver methods
  and their bus_generic_* calls to match.
  
  ## 2. GATEWAY.conf — kernel.bin never gets produced
  arm_install_uboot() expects boot/kernel/kernel.bin, but nothing in the
  pipeline ever creates it (only the plain ELF kernel gets packaged).
  Added an inline objcopy conversion so this is self-sufficient on every
  arm-5G run.
  
  ## Verified against
  - FreeBSD 15.1-RELEASE-p1
  - opnsense-src stable/26.7 @ f6bc838a4c12 (2026-07-16)
  - opnsense-deps master @ 95fd8558bf98 (2026-07-16)
  - FreeBSD ports 2026Q3 
  
  Produced a complete, working 5GB image:
  `OPNsense-202608220646-arm-aarch64-GATEWAY.img`
  
  Related: we-are-mono/opnsense-src#5 (companion fixes for the source
  tree these were built against).
