### PR TITLE
Fix recurring kernel panic in Fman/HC path

### DIFF
--- a/fastpath/cdx/cdx_dpa_ipsec_freebsd.c
+++ b/fastpath/cdx/cdx_dpa_ipsec_freebsd.c
@@ -290,33 +290,39 @@ cdx_ipsec_delete_fp_entry(PSAEntry pSA)
 	}
 
 	if (pSA->ct != NULL && pSA->ct->handle != NULL) {
-		if (ExternalHashTableDeleteKey(pSA->ct->td,
-		    pSA->ct->index, pSA->ct->handle)) {
+		int rc;
+
+		/*
+		 * The table entry belongs to cdx_ehash_delete_entry() on
+		 * every arm of the DeleteKey contract, so the teardown below
+		 * runs unconditionally instead of bailing out with the entry
+		 * still owned by nobody. hw_ct is pure software with no
+		 * hardware reference, so releasing it after a failed delete
+		 * is safe and leaves no stale pointer to a handle this SA no
+		 * longer owns.
+		 *
+		 * The rc is still reported (negative on failure) so callers
+		 * can log; none takes a different action on it -- since the
+		 * teardown here is complete, there is nothing left to defer.
+		 */
+		rc = cdx_ehash_delete_entry(pSA->ct->td, pSA->ct->index,
+		    pSA->ct->handle);
+		if (rc)
 			DPA_ERROR("%s: unable to remove hash table entry\n",
 			    __func__);
-			return (-1);
-		}
-		ExternalHashTableEntryFree(pSA->ct->handle);
 		pSA->ct->handle = NULL;
 		hwct = pSA->ct;
 		pSA->ct = NULL;
 		free(hwct, M_CDX);
+		/*
+		 * Propagate the tri-state (negative on failure) rather than
+		 * flattening to -1; today's callers only test truthiness, so
+		 * this only preserves information.
+		 */
+		if (rc)
+			return (rc);
 	}
 	return (0);
-}
-
-static void
-cdx_ipsec_delete_fp_hash_entry(PSAEntry pSA)
-{
-	struct hw_ct *hwct;
-
-	if (pSA->ct != NULL && pSA->ct->handle != NULL) {
-		ExternalHashTableEntryFree(pSA->ct->handle);
-		pSA->ct->handle = NULL;
-		hwct = pSA->ct;
-		pSA->ct = NULL;
-		free(hwct, M_CDX);
-	}
 }
 
 /*
@@ -353,10 +359,6 @@ cdx_ipsec_release_sa_ctx_cbk(struct timer_entry_t *entry)
 		}
 	}
 
-	/* Free hash table entry if needed */
-	if (pSA->flags & SA_FREE_HASH_ENTRY)
-		cdx_ipsec_delete_fp_hash_entry(pSA);
-
 	/* Remove from FQID lookup list */
 	sa_remove_from_list_fqid(pSA);
 
@@ -374,10 +376,13 @@ cdx_ipsec_release_sa_resources(PSAEntry pSA)
 	int ii, ret;
 
 	pSA->flags |= SA_DELETE;
-
-	/* Delete hash table entry */
-	if (cdx_ipsec_delete_fp_entry(pSA))
-		pSA->flags |= SA_FREE_HASH_ENTRY;
+	/*
+	 * Delete the hash table entry. On failure the callee has already
+	 * disposed of ct/handle under the ehash tri-state (quarantine or
+	 * loud leak) and cleared pSA->ct -- nothing is deferred to the
+	 * release timer any more.
+	 */
+	cdx_ipsec_delete_fp_entry(pSA);
 
 	/* Retire frame queues */
 	if (pSA->pSec_sa_context != NULL &&

--- a/fastpath/cdx/cdx_ehash.c
+++ b/fastpath/cdx/cdx_ehash.c
@@ -491,6 +491,218 @@ static int fill_key_info(PCtEntry entry, uint8_t *keymem, uint32_t port_id)
 	return key_size;
 }
 
+/* Pending-free quarantine for external-hash table entries (ISSUES.md
+ * A80, generalized to every classifier path by A95).
+ *
+ * A table entry leaves a live FMAN chain destructively and before any
+ * barrier - either inside ExternalHashTableDeleteKey() or, for
+ * multicast listeners, through the open-coded splice in
+ * dpa_control_mc.c. A host-command sync (ExternalHashTableFmPcdHcSync)
+ * is what proves that a ucode walker which entered the chain before the
+ * splice has left it; until one succeeds, the unlinked memory may still
+ * be dereferenced by hardware, so it must not go back to the allocator.
+ *
+ * A failed sync therefore leaves an entry that can neither be freed nor
+ * re-unlinked (the surgery is not idempotent - replaying it would walk
+ * pointers that have already been advanced). Park it here instead: the
+ * owning software state is cleared as usual, the memory stays allocated
+ * but unreachable, and the backlog is released the next time any sync
+ * on this PCD succeeds.
+ *
+ * One successful sync clears the whole backlog:
+ * ExternalHashTableFmPcdHcSync() syncs the table handle's PCD, and
+ * LS1046A runs a single FMAN PCD, so a success reached via any table or
+ * any flow is a valid barrier for every entry unlinked before it.
+ *
+ * Concurrency: the quarantine carries no lock of its own. Every touch
+ * runs either from an FCI command handler - serialized by ctrl.mutex in
+ * cdx_cmdhandler.c, with the multicast callers additionally holding
+ * mc_mutators_mutex - from the CT aging kthread, which takes that same
+ * ctrl.mutex, or from module exit with no handler in flight. The query
+ * walkers never see it, so no softirq-safe variant is needed. Callers
+ * must not hold a spinlock: the barriers reached from here busy-wait on
+ * host-command completion.
+ */
+atomic_t cdx_stat_hc_delete_unsynced;
+atomic_t cdx_stat_hc_delete_leaked;
+atomic_t cdx_stat_hc_delete_quarantined;
+
+struct cdx_ehash_pending_free {
+	struct list_head list;
+	void *tbl_entry;
+};
+
+static struct list_head cdx_ehash_pending_frees;
+static int cdx_ehash_pending_frees_initialized;
+static unsigned int cdx_ehash_pending_free_cnt;
+
+static inline void
+cdx_ehash_quarantine_init_once(void)
+{
+	if (!cdx_ehash_pending_frees_initialized) {
+		INIT_LIST_HEAD(&cdx_ehash_pending_frees);
+		cdx_ehash_pending_frees_initialized = 1;
+	}
+}
+
+/* Advisory snapshot for the debug proc readers, which run outside the
+ * mutator serialization. */
+unsigned int cdx_ehash_quarantine_pending(void)
+{
+	return cdx_ehash_pending_free_cnt;
+}
+
+void cdx_ehash_quarantine_entry(void *tbl_entry)
+{
+	struct cdx_ehash_pending_free *node;
+
+	if (!tbl_entry)
+		return;
+
+	cdx_ehash_quarantine_init_once();
+
+	node = kzalloc(sizeof(*node), GFP_KERNEL);
+	if (!node)
+	{
+		/* No safe alternative: the entry is already out of the chain,
+		 * so it can neither be freed without a barrier nor reached
+		 * again through the owning software state. Leak it - the same
+		 * outcome the code had before the quarantine existed - and
+		 * make the leak visible in the log. */
+		DPA_ERROR("%s::quarantine alloc failed, leaking tbl_entry %p\n",
+				__FUNCTION__, tbl_entry);
+		return;
+	}
+	node->tbl_entry = tbl_entry;
+	list_add_tail(&node->list, &cdx_ehash_pending_frees);
+	cdx_ehash_pending_free_cnt++;
+	atomic_inc(&cdx_stat_hc_delete_quarantined);
+}
+
+/* Release the whole backlog. Callers must have just observed a
+ * successful HC sync on this PCD, or be running at module exit where
+ * the PCD teardown has already quiesced the FMAN. Calling it without
+ * such a barrier reintroduces the use-after-free the quarantine exists
+ * to prevent. */
+void cdx_ehash_quarantine_free_all(void)
+{
+	struct cdx_ehash_pending_free *node, *tmp;
+
+	cdx_ehash_quarantine_init_once();
+
+	list_for_each_entry_safe(node, tmp, &cdx_ehash_pending_frees, list)
+	{
+		list_del(&node->list);
+		ExternalHashTableEntryFree(node->tbl_entry);
+		kfree(node);
+	}
+	cdx_ehash_pending_free_cnt = 0;
+}
+
+/* Module-exit disposition of a backlog no drain could clear. cdx does
+ * NOT tear down the FMAN PCD on unload (sdk_fman owns it and stays
+ * loaded), so there is no barrier here either: by this point every
+ * teardown has already retried the sync and failed, meaning the HC
+ * channel is wedged and the ucode may still be walking the parked
+ * memory. Leaking a handful of entries at rmmod (test images only; cdx
+ * is never unloaded in production) is the only safe terminal state. */
+void cdx_ehash_quarantine_abandon(void)
+{
+	struct cdx_ehash_pending_free *node, *tmp;
+
+	cdx_ehash_quarantine_init_once();
+
+	if (!cdx_ehash_pending_free_cnt)
+		return;
+
+	DPA_ERROR("%s::HC channel never recovered, leaking %u quarantined entries\n",
+			__FUNCTION__, cdx_ehash_pending_free_cnt);
+	/* Only the table entries have to be abandoned. The list nodes are
+	 * ordinary kmalloc'd bookkeeping with no hardware reference, so
+	 * release them rather than hand kmemleak a pile of reports that
+	 * hide a real one. */
+	list_for_each_entry_safe(node, tmp, &cdx_ehash_pending_frees, list)
+	{
+		list_del(&node->list);
+		kfree(node);
+	}
+	cdx_ehash_pending_free_cnt = 0;
+}
+
+/* Retry the barrier for entries parked by an earlier failed sync. HC
+ * failures are frequently transient (frame-pool exhaustion rather than a
+ * wedged channel), so the reclaim attempt belongs on the next mutator
+ * that touches the same PCD. Paths that delete a key get the retry for
+ * free through cdx_ehash_delete_entry(); this entry point exists for the
+ * ones that only splice (multicast listener REMOVE/UPDATE), which
+ * otherwise issue no barrier at all. No-op when nothing is pending,
+ * which is the common case. */
+void cdx_ehash_quarantine_drain(void *td)
+{
+	cdx_ehash_quarantine_init_once();
+
+	if (list_empty(&cdx_ehash_pending_frees))
+		return;
+
+	if (ExternalHashTableFmPcdHcSync(td))
+	{
+		DPA_ERROR("%s::FmPcdHcSync failed, %u entries still quarantined\n",
+				__FUNCTION__, cdx_ehash_pending_free_cnt);
+		return;
+	}
+	cdx_ehash_quarantine_free_all();
+}
+
+/* Delete one key from an external hash table and dispose of its table
+ * entry per the ExternalHashTableDeleteKey() tri-state (fm_ehash.h).
+ *
+ * This function owns `handle` from here on: no caller may free it on any
+ * path, and a caller that keeps freeing it reintroduces the A95 defect
+ * class (use-after-free on the not-unlinked arm, premature free on the
+ * unsynced arm). Callers stay responsible for their own software
+ * wrappers only. A NULL handle is tolerated so the "nothing was ever
+ * installed" case needs no guard at every site.
+ *
+ * Returns the raw rc, so callers can still distinguish gone (0) from
+ * unlinked-but-unproven (EN_EHASH_DELETE_UNSYNCED) from
+ * possibly-still-linked (FAILURE) - the last of which additionally means
+ * the key may still resolve in hardware, so re-inserting it would build
+ * a duplicate-key bucket. */
+int cdx_ehash_delete_entry(void *td, uint16_t index, void *handle)
+{
+	int rc;
+
+	if (!handle)
+		return SUCCESS;
+
+	rc = ExternalHashTableDeleteKey(td, index, handle);
+	if (rc == SUCCESS)
+	{
+		ExternalHashTableEntryFree(handle);
+		/* DeleteKey syncs the PCD before reporting success, and one
+		 * sync is a barrier for every entry unlinked before it, so
+		 * this same round-trip retires the whole backlog. */
+		cdx_ehash_quarantine_free_all();
+		return rc;
+	}
+	if (rc == EN_EHASH_DELETE_UNSYNCED)
+	{
+		/* Out of the chain, but no proof the ucode has left it. Park
+		 * it for the next successful sync on this PCD. */
+		atomic_inc(&cdx_stat_hc_delete_unsynced);
+		cdx_ehash_quarantine_entry(handle);
+		return rc;
+	}
+	/* Not provably unlinked, and there is no second unlink to retry: a
+	 * live chain may still resolve to this entry forever. Freeing it -
+	 * now, or later through the quarantine - is a use-after-free the
+	 * hardware commits, so the memory is abandoned deliberately. */
+	atomic_inc(&cdx_stat_hc_delete_leaked);
+	DPA_ERROR("%s::DeleteKey rc %d, leaking tbl_entry %p: not provably unlinked, freeing it would be a use-after-free\n",
+			__FUNCTION__, rc, handle);
+	return rc;
+}
+
 /* check activity */
 void hw_ct_get_active(struct hw_ct *ct)
 {
@@ -526,22 +738,36 @@ static void hw_ct_free_siblings(struct hw_ct *ct)
 	struct hw_ct_sibling *sib = ct->siblings;
 	while (sib) {
 		struct hw_ct_sibling *next = sib->next;
-		ExternalHashTableDeleteKey(sib->td, sib->index, sib->handle);
-		ExternalHashTableEntryFree(sib->handle);
+		(void)cdx_ehash_delete_entry(sib->td, sib->index, sib->handle);
 		kfree(sib);
 		sib = next;
 	}
 	ct->siblings = NULL;
 }
 
-/* delete classif entry from table */
+/* delete classif entry from table.
+ *
+ * Returns the ExternalHashTableDeleteKey() rc (fm_ehash.h): SUCCESS, or
+ * one of the two failure arms. The table entry's disposition belongs to
+ * cdx_ehash_delete_entry() on every arm; what this function owns is the
+ * hw_ct wrapper, which is pure software with no hardware reference and
+ * so is always released. Keeping ct alive past a failed delete bought
+ * nothing and is what let ct_remove() free an already-disposed handle
+ * (ISSUES.md A95). */
 int delete_entry_from_classif_table(PCtEntry entry)
 {
+	int rc;
+
 	if (!entry)
 	{
 		DPA_ERROR("%s:: Ct entry is NULL\n", __FUNCTION__);
 		return FAILURE;
 	}
+	/* ct == NULL is the normal state after ANY earlier delete attempt
+	 * (this function disposes of it on every rc), so a second call for
+	 * the same conntrack must be a successful no-op, not an oops. */
+	if (!entry->ct)
+		return SUCCESS;
 
 	CDX_DPA_DPRINT("\n");
 
@@ -549,24 +775,24 @@ int delete_entry_from_classif_table(PCtEntry entry)
 	if (entry->ct->siblings)
 		hw_ct_free_siblings(entry->ct);
 
-	if (ExternalHashTableDeleteKey(entry->ct->td,
-			entry->ct->index, entry->ct->handle)) {
-                DPA_ERROR("%s::unable to remove entry from hash table\n", __FUNCTION__);
-		return FAILURE;
-	}
-	//free table entry
-	ExternalHashTableEntryFree(entry->ct->handle);
-	entry->ct->handle =  NULL;
+	rc = cdx_ehash_delete_entry(entry->ct->td, entry->ct->index,
+			entry->ct->handle);
+	if (rc)
+		DPA_ERROR("%s::unable to remove entry from hash table\n", __FUNCTION__);
+
 	kfree(entry->ct);
 	entry->ct = NULL;
-	return SUCCESS;
+	return rc;
 }
 
 int delete_pppoe_relay_entry_from_classif_table(pPPPoE_Info entry)
 {
 	struct hw_ct *ct;
+	int rc;
 
 	ct = entry->hw_entry.ct;
+	if (!ct)
+		return SUCCESS;
 
 	CDX_DPA_DPRINT("\n");
 
@@ -574,23 +800,26 @@ int delete_pppoe_relay_entry_from_classif_table(pPPPoE_Info entry)
 	if (ct->siblings)
 		hw_ct_free_siblings(ct);
 
-	if(ExternalHashTableDeleteKey(ct->td,ct->index, ct->handle))
-	{
+	rc = cdx_ehash_delete_entry(ct->td, ct->index, ct->handle);
+	if (rc)
 		DPA_ERROR("%s::unable to remove entry from hash table\n", __FUNCTION__);
-		return FAILURE;
-	}
-	//free table entry
-	ExternalHashTableEntryFree(ct->handle);
-	ct->handle =  NULL;
+
 	kfree(ct);
-	ct = NULL;
-	return SUCCESS;
+	entry->hw_entry.ct = NULL;
+	return rc;
 }
 
-/* delete classif entry from table */
+/* delete classif entry from table.
+ *
+ * The handle's disposition is cdx_ehash_delete_entry()'s. The software
+ * flow is torn down on SUCCESS and on the unsynced arm (the key is out
+ * of the table on both); on a hard FAILURE the flow survives intact as
+ * a tombstone - see the comment at that arm. Returns the delete rc so
+ * the caller can distinguish the arms. */
 int delete_l2br_entry_classif_table(struct L2Flow_entry *entry)
 {
 	struct hw_ct *ct = entry->ct;
+	int rc = SUCCESS;
 
 	if (ct) {
 		/* Remove LAGG sibling entries first */
@@ -599,20 +828,43 @@ int delete_l2br_entry_classif_table(struct L2Flow_entry *entry)
 
 		if (ct->handle) {
 			if (ct->td) {
-				if (ExternalHashTableDeleteKey(ct->td, ct->index, ct->handle)) {
+				rc = cdx_ehash_delete_entry(ct->td, ct->index,
+						ct->handle);
+				if (rc) {
 					DPA_ERROR("%s::unable to remove entry from hash table\n",
 							__FUNCTION__);
-					return FAILURE;
 				}
+				/* Hard failure: the key was not provably
+				 * unlinked, so the software flow must survive
+				 * as a tombstone - it keeps ACTION_REGISTER of
+				 * the same tuple answering ALREADY_EXISTS
+				 * (re-adding a possibly-live key would build a
+				 * duplicate-key bucket), and a later
+				 * DEREGISTER retries this delete (the timer is
+				 * already off the wheel; cdx_timer_del is
+				 * idempotent). ct/handle stay allocated: the
+				 * ucode may still walk them, and the query
+				 * path keeps sampling them safely. */
+				if (rc == FAILURE)
+					return rc;
+			} else {
+				/* No table descriptor: the entry was never
+				 * linked into a chain, so the allocation is
+				 * ours to release outright. */
+				ExternalHashTableEntryFree(ct->handle);
 			}
-			/* free table entry */
-			ExternalHashTableEntryFree(ct->handle);
+			ct->handle = NULL;
 		}
 		kfree(ct);
+		entry->ct = NULL;
 	}
+	/* Unlinked from hardware (or unsynced and parked in the quarantine):
+	 * the software flow is torn down on this arm either way; a later
+	 * lookup can no longer resolve to a flow whose hardware entry is
+	 * gone or pending release. */
 	hlist_del(&entry->node);
 	kfree(entry);
-	return SUCCESS;
+	return rc;
 }
 
 static int get_table_type(PCtEntry entry, uint32_t *type)

--- a/fastpath/cdx/cdx_main_freebsd.c
+++ b/fastpath/cdx/cdx_main_freebsd.c
@@ -73,6 +73,11 @@ cdx_ctrl_deinit(void)
 
 	mutex_lock(&ctrl->mutex);
 	cdx_cmdhandler_exit();
+	/* Last on purpose: the exit chain above (ipsec/socket/ipv4/ipv6
+	 * resets included) can still park entries whose delete failed, so
+	 * the abandon must run after every subsystem's teardown, not from
+	 * an individual _exit hook partway down the chain. */
+	cdx_ehash_quarantine_abandon();
 	mutex_unlock(&ctrl->mutex);
 }
 

--- a/fastpath/cdx/cdx_mc_freebsd.c
+++ b/fastpath/cdx/cdx_mc_freebsd.c
@@ -568,6 +568,21 @@ cdx_create_mcast_group(void *mcast_cmd, int bIsIPv6)
 err_ret:
 	if (pMcastGrpInfo != NULL) {
 		cdx_free_exthash_mcast_members(pMcastGrpInfo);
+		/*
+		 * pMcastGrpInfo->pCtEntry is only assigned inside
+		 * cdx_add_mcast_table_entry()'s success arm, after which the
+		 * caller returns 0 without taking err_ret — so today this
+		 * branch is unreachable.  Any future path that lands here
+		 * with pCtEntry already wired in would silently leak the CT
+		 * chain; freeing it here keeps the err_ret invariant "no
+		 * caller-owned allocation survives" intact.
+		 */
+		if (pMcastGrpInfo->pCtEntry != NULL) {
+			if (pMcastGrpInfo->pCtEntry->pRtEntry != NULL)
+				kfree(pMcastGrpInfo->pCtEntry->pRtEntry);
+			kfree(pMcastGrpInfo->pCtEntry);
+			pMcastGrpInfo->pCtEntry = NULL;
+		}
 		kfree(pMcastGrpInfo);
 	}
 	return (iRet);
@@ -579,13 +594,132 @@ cdx_free_exthash_mcast_members(struct mcast_group_info *pMcastGrpInfo)
 	unsigned int ii;
 
 	FreeMcastGrpID(pMcastGrpInfo->mctype, pMcastGrpInfo->grpid);
-	for (ii = 0; ii < pMcastGrpInfo->uiListenerCnt; ii++) {
-		if (pMcastGrpInfo->members[ii].tbl_entry != NULL)
+	/*
+	 * Walk every slot in members[], not just the first uiListenerCnt:
+	 * after a partial REMOVE followed by UPDATE, valid entries can sit
+	 * at any index, with invalid slots interleaved.  Using uiListenerCnt
+	 * as the loop bound misses the high-index valid entries and leaks
+	 * their ExternalHashTable allocations.  Filter by bIsValidEntry
+	 * (the invariant the rest of this file uses for slot ownership).
+	 */
+	for (ii = 0; ii < MC_MAX_LISTENERS_PER_GROUP; ii++) {
+		if (pMcastGrpInfo->members[ii].bIsValidEntry &&
+		    pMcastGrpInfo->members[ii].tbl_entry != NULL)
 			ExternalHashTableEntryFree(
 			    pMcastGrpInfo->members[ii].tbl_entry);
 	}
 
 	return (0);
+}
+
+/*
+ * Failure-path twin of cdx_free_exthash_mcast_members(): same walk over
+ * every members[] slot with the same bIsValidEntry filter, but the
+ * entries go into the quarantine instead of back to the allocator,
+ * because no HC barrier has proven the ucode is done walking them.
+ * Slots are cleared so nothing can reach the parked memory through the
+ * group again - the group itself is freed right after.
+ */
+static void
+mc_quarantine_members(struct mcast_group_info *pMcastGrpInfo)
+{
+	unsigned int ii;
+
+	for (ii = 0; ii < MC_MAX_LISTENERS_PER_GROUP; ii++) {
+		if (!pMcastGrpInfo->members[ii].bIsValidEntry)
+			continue;
+		cdx_ehash_quarantine_entry(pMcastGrpInfo->members[ii].tbl_entry);
+		pMcastGrpInfo->members[ii].tbl_entry = NULL;
+		pMcastGrpInfo->members[ii].bIsValidEntry = 0;
+	}
+}
+
+/*
+ * Whole-group teardown, shared by the group-DELETE command path, reset,
+ * and future callers so they can't diverge.
+ *
+ * The caller must already have unlinked pMcastGrpInfo from its bucket list.
+ *
+ * Order is load-bearing: the classifier entry leaves the hardware table
+ * first, then the listener table entries, then the CT/route backing memory.
+ * Freeing in the other direction would leave the ucode replicating through
+ * entries whose memory has already been handed back to the allocator.
+ */
+static void
+cdx_mcast_group_destroy(struct mcast_group_info *pMcastGrpInfo)
+{
+	int rc;
+
+	rc = delete_entry_from_classif_table(pMcastGrpInfo->pCtEntry);
+	if (rc == SUCCESS) {
+		/*
+		 * ExternalHashTableDeleteKey() syncs the PCD before
+		 * reporting success, so the classifier entry - and the
+		 * listener chain hanging off it - is provably out of reach
+		 * of the ucode walkers.  Release the members outright, and
+		 * clear the quarantine backlog on the strength of that same
+		 * barrier.
+		 */
+		cdx_free_exthash_mcast_members(pMcastGrpInfo);
+		cdx_ehash_quarantine_free_all();
+	} else if (rc == EN_EHASH_DELETE_UNSYNCED) {
+		/*
+		 * The classifier key left the table but the HC barrier
+		 * failed, so the listener entries are in exactly the state
+		 * the per-listener REMOVE path quarantines: gone from
+		 * software, unproven in hardware.  Park them rather than
+		 * free them.  The group id is released either way - it is
+		 * pure software bookkeeping, and
+		 * cdx_free_exthash_mcast_members() (skipped here) is where
+		 * it normally happens.
+		 *
+		 * The classifier's own table entry is in the same
+		 * unlinked-but-unsynced state as the members; parking it,
+		 * and releasing its software-only hw_ct wrapper, is
+		 * delete_entry_from_classif_table()'s job.
+		 */
+		FreeMcastGrpID(pMcastGrpInfo->mctype, pMcastGrpInfo->grpid);
+		mc_quarantine_members(pMcastGrpInfo);
+	} else {
+		/*
+		 * The classifier key was NOT provably unlinked (invalid
+		 * table state), so the ucode may still resolve it and
+		 * replicate through the listener chain indefinitely.  These
+		 * entries must never reach the allocator - not now, and not
+		 * via the quarantine, whose backlog is freed on the next
+		 * successful sync.  Leak them loudly and clear the slots so
+		 * nothing else can.  The group id is software bookkeeping
+		 * and is released regardless.
+		 */
+		unsigned int ii, leaked;
+
+		leaked = 0;
+		FreeMcastGrpID(pMcastGrpInfo->mctype, pMcastGrpInfo->grpid);
+		for (ii = 0; ii < MC_MAX_LISTENERS_PER_GROUP; ii++) {
+			if (!pMcastGrpInfo->members[ii].bIsValidEntry)
+				continue;
+			pMcastGrpInfo->members[ii].tbl_entry = NULL;
+			pMcastGrpInfo->members[ii].bIsValidEntry = 0;
+			leaked++;
+		}
+		/*
+		 * The classifier's own table entry leaks with the members
+		 * (it may still be linked); delete_entry_from_classif_table()
+		 * already abandoned it and released its software-only hw_ct
+		 * wrapper.
+		 */
+		DPA_ERROR("%s: classifier delete failed pre-unlink (rc %d), "
+		    "leaking %u listener entries + the classifier entry\n",
+		    __func__, rc, leaked);
+	}
+
+	if (pMcastGrpInfo->pCtEntry != NULL) {
+		if (pMcastGrpInfo->pCtEntry->pRtEntry != NULL)
+			kfree(pMcastGrpInfo->pCtEntry->pRtEntry);
+		kfree(pMcastGrpInfo->pCtEntry);
+		pMcastGrpInfo->pCtEntry = NULL;
+	}
+	kfree(pMcastGrpInfo);
 }
 
 static void
@@ -675,6 +809,13 @@ cdx_update_mcast_group(void *mcast_cmd, int bIsIPv6)
 	}
 
 	pMcastGrpInfo = pTempGrpInfo;
+
+	/*
+	 * Reclaim anything a previous failed barrier left parked before
+	 * touching the chain again.  Cheap: no-op unless something is
+	 * pending, and the group is resolved so the PCD handle is valid.
+	 */
+	cdx_ehash_quarantine_drain(pMcastGrpInfo->pCtEntry->ct->td);
 
 	if (uiNoOfListeners + pMcastGrpInfo->uiListenerCnt >
 	    MC_MAX_LISTENERS_PER_GROUP) {
@@ -835,17 +976,91 @@ cdx_delete_mcast_group_member(void *mcast_cmd, int bIsIPv6)
 
 	pMcastGrpInfo = pTempGrpInfo;
 
+	/*
+	 * Reclaim anything a previous failed barrier left parked before
+	 * touching the chain again.  Cheap: no-op unless something is
+	 * pending, and the group is resolved so the PCD handle is valid.
+	 */
+	cdx_ehash_quarantine_drain(pMcastGrpInfo->pCtEntry->ct->td);
+
+	/*
+	 * Validate every listener in the request actually exists in the
+	 * group before touching any state.  The count-match fast path
+	 * below (and the per-listener loop further down) used to assume
+	 * the request was well-formed: REMOVE [foo] against a group
+	 * { bar } whose count happened to equal 1 would hit the fast
+	 * path and delete the whole group, even though `foo` was never
+	 * a member.  Validating up-front rejects mismatched requests
+	 * atomically, before either path mutates members[] or unlinks
+	 * the group.
+	 *
+	 * Also dedupe by tracking which members[] slot each requested
+	 * name resolved to.  A request like REMOVE [a, a] against
+	 * { a, b } would otherwise validate twice against the same
+	 * member_id, the count-match fast path would trigger, and the
+	 * whole group would be wiped.  MC_MAX_LISTENERS_PER_GROUP is 8
+	 * so a u8 bitmap fits the slot space exactly.
+	 */
+	{
+		uint8_t seen_members = 0;
+		int found_id;
+
+		for (ii = 0; ii < (int)uiNoOfListeners; ii++) {
+			if (bIsIPv6)
+				pListener = &mcast6_group->output_list[ii];
+			else
+				pListener = &mcast4_group->output_list[ii];
+			found_id = Cdx_GetMcastMemberId(
+			    (char *)pListener->output_device_str,
+			    pMcastGrpInfo);
+			if (found_id == -1) {
+				DPA_ERROR("%s: member %s does not exist "
+				    "in group\n", __func__,
+				    pListener->output_device_str);
+				iRet = -1;
+				goto err_ret;
+			}
+			if (seen_members & (1u << found_id)) {
+				DPA_ERROR("%s: duplicate listener %s in "
+				    "REMOVE\n", __func__,
+				    pListener->output_device_str);
+				iRet = -1;
+				goto err_ret;
+			}
+			seen_members |= (1u << found_id);
+		}
+	}
+
 	/* If removing all listeners, delete the entire group */
 	if (pMcastGrpInfo->uiListenerCnt == uiNoOfListeners) {
-		delete_entry_from_classif_table(pMcastGrpInfo->pCtEntry);
-		cdx_free_exthash_mcast_members(pMcastGrpInfo);
-		if (pMcastGrpInfo->pCtEntry != NULL) {
-			if (pMcastGrpInfo->pCtEntry->pRtEntry != NULL)
-				kfree(pMcastGrpInfo->pCtEntry->pRtEntry);
-			kfree(pMcastGrpInfo->pCtEntry);
+		/*
+		 * Unlink the group from the per-bucket list under the
+		 * spinlock that also guards the FMan packet path's view of
+		 * the member chain (see the locking model above; query is
+		 * serialized out by ctrl->mutex and never contends on this
+		 * lock).  Once we release the lock, the node is gone from
+		 * the list and the chain it heads is unreachable from a new
+		 * lookup, so the rest of teardown (HW table evict + listener
+		 * tbl_entry frees/quarantine + pCtEntry/pRtEntry/group frees)
+		 * runs unlocked - those steps issue hardware completions and
+		 * can block waiting on them, which would needlessly hold up
+		 * every other bucket-N mutator for the duration.  The
+		 * per-listener REMOVE loop below likewise unlocks before its
+		 * own hardware completion wait.
+		 */
+		if (pMcastGrpInfo->mctype == 0) {
+			uiHash = HASH_MC4(pMcastGrpInfo->ipv4_daddr);
+			spin_lock(&mc4_spinlocks[uiHash]);
+			list_del(&pMcastGrpInfo->list);
+			spin_unlock(&mc4_spinlocks[uiHash]);
+		} else {
+			uiHash = HASH_MC6((void *)pMcastGrpInfo->ipv6_daddr);
+			spin_lock(&mc6_spinlocks[uiHash]);
+			list_del(&pMcastGrpInfo->list);
+			spin_unlock(&mc6_spinlocks[uiHash]);
 		}
-		list_del(&pMcastGrpInfo->list);
-		kfree(pMcastGrpInfo);
+
+		cdx_mcast_group_destroy(pMcastGrpInfo);
 		return (0);
 	}
 
@@ -926,10 +1141,29 @@ cdx_delete_mcast_group_member(void *mcast_cmd, int bIsIPv6)
 		if (ExternalHashTableFmPcdHcSync(
 		    pMcastGrpInfo->pCtEntry->ct->td)) {
 			DPA_ERROR("%s: FmPcdHcSync failed\n", __func__);
+			/*
+			 * The splice above already happened, so the entry
+			 * is out of the chain but has no barrier proving the
+			 * ucode left it.  It cannot be freed here and cannot
+			 * be unlinked a second time.  Park it; the next
+			 * mutator that reaches this PCD reclaims it.
+			 *
+			 * Abandon the rest of the batch: a sync failure is a
+			 * property of the HC channel, not of this listener,
+			 * so every remaining member would fail the same way
+			 * and pile up more quarantined entries.
+			 */
+			cdx_ehash_quarantine_entry(tbl_entry);
 			return (-1);
 		}
 
 		ExternalHashTableEntryFree(tbl_entry);
+		/*
+		 * That sync is a barrier for the whole PCD, not just this
+		 * entry - anything parked by an earlier failure is now
+		 * provably walker-free too, with no second round-trip.
+		 */
+		cdx_ehash_quarantine_free_all();
 	}
 
 err_ret:
@@ -1057,24 +1291,22 @@ static void
 mc4_reset(void)
 {
 	struct mcast_group_info *grp;
-	struct list_head *pos, *tmp;
 	int ii;
 
 	for (ii = 0; ii < MC4_NUM_HASH_ENTRIES; ii++) {
-		spin_lock(&mc4_spinlocks[ii]);
-		list_for_each_safe(pos, tmp, &mc4_grp_list[ii]) {
-			grp = list_entry(pos, struct mcast_group_info, list);
-			delete_entry_from_classif_table(grp->pCtEntry);
-			cdx_free_exthash_mcast_members(grp);
-			list_del(pos);
-			if (grp->pCtEntry != NULL) {
-				if (grp->pCtEntry->pRtEntry != NULL)
-					kfree(grp->pCtEntry->pRtEntry);
-				kfree(grp->pCtEntry);
+		for (;;) {
+			spin_lock(&mc4_spinlocks[ii]);
+			if (list_empty(&mc4_grp_list[ii])) {
+				spin_unlock(&mc4_spinlocks[ii]);
+				break;
 			}
-			kfree(grp);
+			grp = list_first_entry(&mc4_grp_list[ii],
+			    struct mcast_group_info, list);
+			list_del(&grp->list);
+			spin_unlock(&mc4_spinlocks[ii]);
+
+			cdx_mcast_group_destroy(grp);
 		}
-		spin_unlock(&mc4_spinlocks[ii]);
 	}
 }
 
@@ -1082,24 +1314,22 @@ static void
 mc6_reset(void)
 {
 	struct mcast_group_info *grp;
-	struct list_head *pos, *tmp;
 	int ii;
 
 	for (ii = 0; ii < MC6_NUM_HASH_ENTRIES; ii++) {
-		spin_lock(&mc6_spinlocks[ii]);
-		list_for_each_safe(pos, tmp, &mc6_grp_list[ii]) {
-			grp = list_entry(pos, struct mcast_group_info, list);
-			delete_entry_from_classif_table(grp->pCtEntry);
-			cdx_free_exthash_mcast_members(grp);
-			list_del(pos);
-			if (grp->pCtEntry != NULL) {
-				if (grp->pCtEntry->pRtEntry != NULL)
-					kfree(grp->pCtEntry->pRtEntry);
-				kfree(grp->pCtEntry);
+		for (;;) {
+			spin_lock(&mc6_spinlocks[ii]);
+			if (list_empty(&mc6_grp_list[ii])) {
+				spin_unlock(&mc6_spinlocks[ii]);
+				break;
 			}
-			kfree(grp);
+			grp = list_first_entry(&mc6_grp_list[ii],
+			    struct mcast_group_info, list);
+			list_del(&grp->list);
+			spin_unlock(&mc6_spinlocks[ii]);
+
+			cdx_mcast_group_destroy(grp);
 		}
-		spin_unlock(&mc6_spinlocks[ii]);
 	}
 }
 

--- a/fastpath/cdx/cdx_sysctl.c
+++ b/fastpath/cdx/cdx_sysctl.c
@@ -56,6 +56,42 @@ sysctl_cdx_active_conn(SYSCTL_HANDLER_ARGS)
 	return (sysctl_handle_long(oidp, &val, 0, req));
 }
 
+static int
+sysctl_cdx_hc_delete_unsynced(SYSCTL_HANDLER_ARGS)
+{
+	unsigned long val;
+
+	val = (unsigned long)atomic_read(&cdx_stat_hc_delete_unsynced);
+	return (sysctl_handle_long(oidp, &val, 0, req));
+}
+
+static int
+sysctl_cdx_hc_delete_leaked(SYSCTL_HANDLER_ARGS)
+{
+	unsigned long val;
+
+	val = (unsigned long)atomic_read(&cdx_stat_hc_delete_leaked);
+	return (sysctl_handle_long(oidp, &val, 0, req));
+}
+
+static int
+sysctl_cdx_hc_delete_quarantined(SYSCTL_HANDLER_ARGS)
+{
+	unsigned long val;
+
+	val = (unsigned long)atomic_read(&cdx_stat_hc_delete_quarantined);
+	return (sysctl_handle_long(oidp, &val, 0, req));
+}
+
+static int
+sysctl_cdx_hc_delete_quarantine_pending(SYSCTL_HANDLER_ARGS)
+{
+	unsigned long val;
+
+	val = (unsigned long)cdx_ehash_quarantine_pending();
+	return (sysctl_handle_long(oidp, &val, 0, req));
+}
+
 void
 cdx_sysctl_init(void)
 {
@@ -93,6 +129,33 @@ cdx_sysctl_init(void)
 	    SYSCTL_CHILDREN(stats_node), OID_AUTO, "timer_ticks",
 	    CTLFLAG_RD, &cdx_stat_timer_ticks,
 	    "Timer wheel ticks");
+
+	SYSCTL_ADD_PROC(&cdx_sysctl_ctx,
+	    SYSCTL_CHILDREN(stats_node), OID_AUTO, "hc_delete_unsynced",
+	    CTLTYPE_ULONG | CTLFLAG_RD | CTLFLAG_MPSAFE,
+	    NULL, 0, sysctl_cdx_hc_delete_unsynced, "LU",
+	    "ExternalHashTableDeleteKey() calls returning EN_EHASH_DELETE_UNSYNCED "
+	    "(unlinked, HC sync unconfirmed -- transient, resolved by quarantine)");
+
+	SYSCTL_ADD_PROC(&cdx_sysctl_ctx,
+	    SYSCTL_CHILDREN(stats_node), OID_AUTO, "hc_delete_leaked",
+	    CTLTYPE_ULONG | CTLFLAG_RD | CTLFLAG_MPSAFE,
+	    NULL, 0, sysctl_cdx_hc_delete_leaked, "LU",
+	    "ExternalHashTableDeleteKey() calls returning hard FAILURE -- entry "
+	    "never provably unlinked, permanently abandoned");
+
+	SYSCTL_ADD_PROC(&cdx_sysctl_ctx,
+	    SYSCTL_CHILDREN(stats_node), OID_AUTO, "hc_delete_quarantined",
+	    CTLTYPE_ULONG | CTLFLAG_RD | CTLFLAG_MPSAFE,
+	    NULL, 0, sysctl_cdx_hc_delete_quarantined, "LU",
+	    "Entries ever parked in the delete quarantine");
+
+	SYSCTL_ADD_PROC(&cdx_sysctl_ctx,
+	    SYSCTL_CHILDREN(stats_node), OID_AUTO,
+	    "hc_delete_quarantine_pending",
+	    CTLTYPE_ULONG | CTLFLAG_RD | CTLFLAG_MPSAFE,
+	    NULL, 0, sysctl_cdx_hc_delete_quarantine_pending, "LU",
+	    "Current delete-quarantine backlog size");
 }
 
 void

--- a/fastpath/include/cdx.h
+++ b/fastpath/include/cdx.h
@@ -55,6 +55,9 @@
 typedef void (*cdx_deinit_func)(void);
 void register_cdx_deinit_func(cdx_deinit_func func);
 extern atomic_t num_active_connections;
+extern atomic_t cdx_stat_hc_delete_unsynced;
+extern atomic_t cdx_stat_hc_delete_leaked;
+extern atomic_t cdx_stat_hc_delete_quarantined;
 extern struct cdx_fman_info *fman_info;
 
 /* qosconnmark definitions */

--- a/fastpath/include/fm_ehash.h
+++ b/fastpath/include/fm_ehash.h
@@ -701,6 +701,8 @@ display_ehash_tbl_entry(struct en_ehash_entry *entry __attribute__((unused)),
 {
 }
 
+#define EN_EHASH_DELETE_UNSYNCED	(-2)
+
 /* ----------------------------------------------------------------
  * ExternalHash API
  * ---------------------------------------------------------------- */

--- a/fastpath/vendor/cdx/cdx.h
+++ b/fastpath/vendor/cdx/cdx.h
@@ -54,6 +54,9 @@
 typedef void (*cdx_deinit_func)(void);
 void register_cdx_deinit_func(cdx_deinit_func func);
 extern atomic_t num_active_connections;
+extern atomic_t cdx_stat_hc_delete_unsynced;
+extern atomic_t cdx_stat_hc_delete_leaked;
+extern atomic_t cdx_stat_hc_delete_quarantined;
 extern struct cdx_fman_info *fman_info;
 
 /* qosconnmark definitions */

--- a/fastpath/vendor/cdx/cdx_common.h
+++ b/fastpath/vendor/cdx/cdx_common.h
@@ -394,6 +394,27 @@ int cdx_init_ip_reassembly(void);
 
 void hw_ct_get_active(struct hw_ct *ct);
 
+/* External-hash entry disposition (ISSUES.md A95; implemented in
+ * cdx_ehash.c, where the full rationale lives).
+ *
+ * Every path that removes a key from an FMAN external hash table must go
+ * through cdx_ehash_delete_entry(): ExternalHashTableDeleteKey()'s
+ * tri-state (fm_ehash.h) decides whether the table entry may be freed,
+ * must be parked until a later host-command barrier proves the ucode has
+ * left it, or must be leaked forever. cdx_ehash_delete_entry() owns the
+ * handle on every arm; callers free only their own software wrappers.
+ *
+ * Serialization: no lock of their own. Callers run under the FCI
+ * ctrl.mutex (cdx_cmdhandler_freebsd.c) or at module exit with no handler
+ * in flight. Not callable under a spinlock: the barriers busy-wait on
+ * host-command completion. */
+int cdx_ehash_delete_entry(void *td, uint16_t index, void *handle);
+void cdx_ehash_quarantine_entry(void *tbl_entry);
+void cdx_ehash_quarantine_free_all(void);
+void cdx_ehash_quarantine_drain(void *td);
+void cdx_ehash_quarantine_abandon(void);
+unsigned int cdx_ehash_quarantine_pending(void);
+
 int cdx_set_expt_rate(uint32_t fm_index, uint32_t type, uint32_t limit, uint32_t burst_size);
 int cdx_get_expt_rate(void *cmd);
 int cdx_set_ff_rate(char *ifname, uint32_t cir, uint32_t pir);

--- a/fastpath/vendor/cdx/control_ipsec.c
+++ b/fastpath/vendor/cdx/control_ipsec.c
@@ -145,8 +145,8 @@ void* M_ipsec_get_matched_natt_tunnel(PSAEntry sa)
 			if (!IS_NATT_SA(sa))
 				continue;
 			/* This SA is under release process */
-			if (pEntry->flags & SA_FREE_HASH_ENTRY)
-				continue; 
+			if (pEntry->flags & SA_DELETE)
+				continue;
 #ifdef CONTROL_IPSEC_DEBUG
 			printk("%x:%x - %x:%x - %x:%x - %x:%x - %x:%x - %x:%x - %x:%x - %x:%x - %x:%x - %x:%x - %x:%x - %x:%x\n", \
 				pEntry->natt.sport,  sa->natt.sport, pEntry->natt.dport,  \

--- a/fastpath/vendor/cdx/control_ipsec.h
+++ b/fastpath/vendor/cdx/control_ipsec.h
@@ -339,7 +339,8 @@ typedef struct _tSAID {
 /* flag to indicate in SA whether the shared descriptor already built or not */
 #define SA_SH_DESC_BUILT	0x80 
 #define SA_DELETE		0x100
-#define SA_FREE_HASH_ENTRY	0x200
+/* 0x200 retired (was SA_FREE_HASH_ENTRY, a deferred-free latch made dead
+ * by the ehash delete owning ct/handle disposition on every rc) */
 #define SA_FQ_WAIT_B4_FREE	0x400 /* reserve 3 bits starting from 0x400 */
 
 #define SA_HDR_COPY_TOS  1

--- a/fastpath/vendor/cdx/control_ipv4.c
+++ b/fastpath/vendor/cdx/control_ipv4.c
@@ -186,27 +186,15 @@ void ct_remove(PCtEntry pEntry_orig)
 
 	cdx_timer_del(&ppair->timer);
 
+	/* delete_entry_from_classif_table() owns the classifier entry on
+	 * every arm of the DeleteKey contract and always releases the hw_ct
+	 * wrapper, so there is nothing left here to dispose of - including
+	 * after an earlier CONNTRACK_DEL_FAILED, where ct is already NULL
+	 * and the table entry was deliberately abandoned (ISSUES.md A95). */
 	if ((pEntry_orig->status & CONNTRACK_HWSET) && delete_entry_from_classif_table(pEntry_orig))
 		DPRINT_ERROR("failed to delete orig entry\n");
 	if ((pEntry_rep->status & CONNTRACK_HWSET) && delete_entry_from_classif_table(pEntry_rep))
 		DPRINT_ERROR("failed to delete reply entry\n");
-
-	if (pEntry_orig->status & CONNTRACK_DEL_FAILED)
-	{
-		/* free table entry */
-		ExternalHashTableEntryFree(pEntry_orig->ct->handle);
-		pEntry_orig->ct->handle =  NULL;
-		kfree(pEntry_orig->ct);
-		pEntry_orig->ct = NULL;
-	}
-	if (pEntry_rep->status & CONNTRACK_DEL_FAILED)
-	{
-		/* free table entry */
-		ExternalHashTableEntryFree(pEntry_rep->ct->handle);
-		pEntry_rep->ct->handle =  NULL;
-		kfree(pEntry_rep->ct);
-		pEntry_rep->ct = NULL;
-	}
 
 	IP_delete_CT_route(pEntry_orig);
 	IP_delete_CT_route(pEntry_rep);
@@ -244,6 +232,25 @@ void ct_update_one(PCtEntry pEntry)
 	if (!(pEntry->status & CONNTRACK_HWSET)){
 		if(is_CT_COMPLETE(pEntry))
 		{
+			/* CONNTRACK_DEL_FAILED means an earlier delete bailed
+			 * out before the key was provably unlinked, so the old
+			 * key may still resolve in the hardware table. Adding
+			 * the same key again would build a duplicate-key bucket
+			 * whose two entries carry different actions, and only
+			 * one of them is reachable for a later delete. There is
+			 * no way back from that state, so refuse the
+			 * re-offload; the stale key may well keep fast-pathing
+			 * the 5-tuple with its old action, but adding a second
+			 * one cannot improve that and makes it unrecoverable
+			 * (ISSUES.md A95). EN_EHASH_DELETE_UNSYNCED does not set the flag:
+			 * there the key *is* out of the table, only the barrier
+			 * is missing, and the parked entry is the quarantine's
+			 * to release. */
+			if (pEntry->status & CONNTRACK_DEL_FAILED)
+			{
+				DPRINT_ERROR("refusing to re-offload a conntrack whose classifier key was never provably unlinked; re-inserting it would duplicate the key\n");
+				return;
+			}
 			rc = insert_entry_in_classif_table(pEntry);
 			if (rc)
 				DPRINT_ERROR("failed to insert entry\n");
@@ -258,13 +265,14 @@ void ct_update_one(PCtEntry pEntry)
 			 delete the entry from classification table till an update is received.*/
 		rc = delete_entry_from_classif_table(pEntry);
 		if(rc)
-		{
-			pEntry->status |= CONNTRACK_DEL_FAILED;
-			pEntry->status &= ~CONNTRACK_HWSET;
 			DPRINT_ERROR("failed to delete entry\n");
-		}
-		else
-			pEntry->status &= ~CONNTRACK_HWSET;
+		/* Pre-unlink failure only: the key may still be live in the
+		 * table, which permanently bars a re-offload of this flow. An
+		 * unsynced delete leaves the key provably out, so it does not
+		 * earn the flag. */
+		if (rc && rc != EN_EHASH_DELETE_UNSYNCED)
+			pEntry->status |= CONNTRACK_DEL_FAILED;
+		pEntry->status &= ~CONNTRACK_HWSET;
 
 		return;
 	}

--- a/fastpath/vendor/cdx/control_rtp_relay.c
+++ b/fastpath/vendor/cdx/control_rtp_relay.c
@@ -291,19 +291,30 @@ static void rtp_flow_link(struct _thw_rtpflow *hw_flow, U32 hash)
 }
 
 #endif // 0
-/* remove a hardware flow entry from the packet engine hash */
-static void rtp_flow_unlink(struct _thw_rtpflow *hw_flow, U32 hash)
+/* remove a hardware flow entry from the packet engine hash
+ *
+ * Returns the cdx_ehash_delete_entry() tri-state so a caller that re-adds
+ * the same key can refuse to do so when the delete did not provably unlink
+ * it. On a hard failure the handle is kept, not cleared: the flow stays a
+ * tombstone pointing at the still-live entry, so a later unlink retries the
+ * delete instead of losing track of it and a re-point can decline to build
+ * a duplicate key over it. The success and unsynced arms leave the key
+ * provably out of the table, so the handle is cleared there as before. */
+static int rtp_flow_unlink(struct _thw_rtpflow *hw_flow)
 {
-	if ((hw_flow->eeh_entry_handle) &&
-			(ExternalHashTableDeleteKey(hw_flow->td, 
-																	hw_flow->eeh_entry_index, hw_flow->eeh_entry_handle))) 
-	{
+	int rc;
+
+	/* The table entry belongs to cdx_ehash_delete_entry() on every arm
+	 * of the DeleteKey contract (it tolerates a NULL handle); freeing it
+	 * here after a failed delete was a use-after-free (ISSUES.md A95). */
+	rc = cdx_ehash_delete_entry(hw_flow->td, hw_flow->eeh_entry_index,
+			hw_flow->eeh_entry_handle);
+	if (rc) {
 		DPA_ERROR("%s(%d)::unable to remove entry from hash table\n", __FUNCTION__, __LINE__);
 	}
-	//free table entry
-	if (hw_flow->eeh_entry_handle)
-		ExternalHashTableEntryFree(hw_flow->eeh_entry_handle);
-	hw_flow->eeh_entry_handle =  NULL;
+	if (rc == SUCCESS || rc == EN_EHASH_DELETE_UNSYNCED)
+		hw_flow->eeh_entry_handle = NULL;
+	return rc;
 }
 
 static void rtp_flow_remove(PRTPflow pFlow)
@@ -315,7 +326,7 @@ static void rtp_flow_remove(PRTPflow pFlow)
 	if ((hw_flow = pFlow->hw_flow))
 	{
 		/* remove it in ucode  */
-		rtp_flow_unlink(hw_flow, 0);
+		rtp_flow_unlink(hw_flow);
 
 	}
 
@@ -354,6 +365,7 @@ static int RTP_change_flow(PRTPflow pFlow, U16 ingress_socketID, U16 egress_sock
 {
 	struct _thw_rtpflow *hw_flow = pFlow->hw_flow;
 	U32	hash;
+	int	rc;
 
 	pFlow->takeover_resync = TRUE;
 	pFlow->rtp_info.first_packet = TRUE;
@@ -361,7 +373,15 @@ static int RTP_change_flow(PRTPflow pFlow, U16 ingress_socketID, U16 egress_sock
 	hash = HASH_RTP(pFlow->ingress_socketID);
 
 	// delete the previous entry in ucode
-	rtp_flow_unlink(hw_flow, hash);
+	rc = rtp_flow_unlink(hw_flow);
+	/* A hard delete failure means the old classifier key was not provably
+	 * unlinked; the re-add further down would build a duplicate-key bucket
+	 * for this flow. Refuse the re-point before any software state changes,
+	 * leaving the flow on its still-live entry for a later change to retry.
+	 * The success and unsynced arms leave the key provably out of the
+	 * table, so the re-add is safe there. */
+	if (rc && rc != EN_EHASH_DELETE_UNSYNCED)
+		return -1;
 
 	/* now managing changes in software flow */
 	slist_remove(&rtpflow_cache[hash], &pFlow->list);

--- a/fastpath/vendor/cdx/control_socket.c
+++ b/fastpath/vendor/cdx/control_socket.c
@@ -636,6 +636,7 @@ int SOCKET4_HandleIP_Socket_Update (U16 *p, U16 Length)
 		void 				*td;
 		void				*eeh_entry_handle;
 		uint16_t			 eeh_entry_index;
+		int					 del_rc;
 
 		// egress rtp flow should be modified with route info, etc.
 		// deleting old entry and creating new one
@@ -647,7 +648,7 @@ int SOCKET4_HandleIP_Socket_Update (U16 *p, U16 Length)
 		{
 			DPA_ERROR("%s(%d) error in finding ingress socket\n", __FUNCTION__, __LINE__);
 			return ERR_SOCK_UPDATE_ERR;
-		}	
+		}
 		if(!pingress_socket->pRtEntry)
 		{
 			DPA_INFO("%s(%d) missing route, checking for route\n",
@@ -668,15 +669,31 @@ int SOCKET4_HandleIP_Socket_Update (U16 *p, U16 Length)
 		pFlow->hw_flow->eeh_entry_handle =  NULL;
 		pFlow->hw_flow->eeh_entry_index = 0;
 
-		if (ExternalHashTableDeleteKey(td, 
-				eeh_entry_index, 
-				eeh_entry_handle)) {
+		/* Break-before-make: the old key is deleted before the updated
+		 * one is added. The table entry belongs to cdx_ehash_delete_entry()
+		 * on every arm of the DeleteKey contract - freeing it here after a
+		 * failed delete was a use-after-free (ISSUES.md A95).
+		 *
+		 * If the delete did not provably unlink the key, adding it again
+		 * would build a duplicate-key bucket for this flow. Refuse the
+		 * re-add, hand the flow back its reference to the still-live entry
+		 * so a later update retries the delete, and fail the command. The
+		 * success and unsynced arms leave the key provably out, so the
+		 * re-add is safe there. */
+		del_rc = cdx_ehash_delete_entry(td, eeh_entry_index,
+				eeh_entry_handle);
+		if (del_rc && del_rc != EN_EHASH_DELETE_UNSYNCED) {
+			DPA_ERROR("%s(%d)::classifier key not provably unlinked; refusing re-add to avoid a duplicate-key bucket\n",
+				__FUNCTION__, __LINE__);
+			pFlow->hw_flow->eeh_entry_handle = eeh_entry_handle;
+			pFlow->hw_flow->eeh_entry_index = eeh_entry_index;
+			return ERR_SOCK_UPDATE_ERR;
+		}
+		if (del_rc) {
 			DPA_ERROR("%s(%d)::unable to remove entry from hash table\n",
 				__FUNCTION__, __LINE__);
 		}
-		//free table entry
-		ExternalHashTableEntryFree(eeh_entry_handle);
-		
+
 		/* reflect changes to hardware flow */
 		// create an entry in ehash table
 		if(cdx_create_rtp_conn_in_classif_table(pFlow, pingress_socket, pEntry))
@@ -734,15 +751,13 @@ int SOCKET4_HandleIP_Socket_Close (U16 *p, U16 Length)
 	if (pEntry->SocketType == SOCKET_TYPE_MSP) {
 		/* deleting entry */
 
-		if (ExternalHashTableDeleteKey(pEntry->SktEhTblHdl.td, 
-			pEntry->SktEhTblHdl.eeh_entry_index, 
+		if (cdx_ehash_delete_entry(pEntry->SktEhTblHdl.td,
+			pEntry->SktEhTblHdl.eeh_entry_index,
 			pEntry->SktEhTblHdl.eeh_entry_handle)) {
 			DPA_ERROR("%s(%d)::unable to remove entry from hash table\n",
 					__FUNCTION__, __LINE__);
 		}
-		/* free table entry */
-		ExternalHashTableEntryFree(pEntry->SktEhTblHdl.eeh_entry_handle);
-		DPA_INFO("%s()::%d Successfully deleted old extended hash table key and entry:\n", 
+		DPA_INFO("%s()::%d Successfully deleted old extended hash table key and entry:\n",
 							__func__, __LINE__);
 	}
 #endif/*endif for VOIP_PRIORITY_SLOW_PATH_FRAME_QUEUES */
@@ -1000,6 +1015,7 @@ int SOCKET6_HandleIP_Socket_Update(U16 *p, U16 Length)
 		void				*td;
 		void				*eeh_entry_handle;
 		uint16_t		eeh_entry_index;
+		int				del_rc;
 
 		// egress rtp flow should be modified with route info, etc.
 		// deleting old entry and creating new one
@@ -1042,17 +1058,31 @@ int SOCKET6_HandleIP_Socket_Update(U16 *p, U16 Length)
 		}
 
 
-		if (ExternalHashTableDeleteKey(td, 
-				eeh_entry_index, 
-				eeh_entry_handle))
-		{
+		/* Make-before-break: unlike the v4 path, v6 adds the updated key
+		 * while the old one is still live, so a running RTP socket is
+		 * never left without a classifier entry mid-update. The old key is
+		 * only deleted once the new one is in place; the two coexist for
+		 * that window by design.
+		 *
+		 * The re-add has therefore already happened by the time the delete
+		 * runs, so the v4-style "refuse the re-add on a failed delete" gate
+		 * cannot apply here - there is no re-add left to withhold. A hard
+		 * delete failure leaves the old key as a leaked duplicate of the
+		 * new one; report it loudly but do not fail the command, because
+		 * the new entry is in place and correct and failing would only
+		 * invite a retry that adds yet another copy of the same key. The
+		 * table entry itself belongs to cdx_ehash_delete_entry() on every
+		 * arm - freeing it here would be the A95 use-after-free. */
+		del_rc = cdx_ehash_delete_entry(td, eeh_entry_index,
+				eeh_entry_handle);
+		if (del_rc && del_rc != EN_EHASH_DELETE_UNSYNCED) {
+			DPA_ERROR("%s(%d)::old classifier key not provably unlinked; leaked as a duplicate of the updated key\n",
+				__FUNCTION__, __LINE__);
+		} else if (del_rc) {
 			DPA_ERROR("%s(%d)::unable to remove entry from hash table\n",
 				__FUNCTION__, __LINE__);
 		}
-		//free table entry
-		ExternalHashTableEntryFree(eeh_entry_handle);
 
-		
 		if (cdx_rtp_set_hwinfo_fields(pFlow, pingress_socket) != 0)
 		{
 			DPA_ERROR("%s(%d) Error in setting rtp hwinfo fields.\n", __FUNCTION__,__LINE__);
@@ -1102,15 +1132,13 @@ int SOCKET6_HandleIP_Socket_Close(U16 *p, U16 Length)
 	if (pEntry->SocketType == SOCKET_TYPE_MSP) {
 		/* deleting entry */
 
-		if (ExternalHashTableDeleteKey(pEntry->SktEhTblHdl.td, 
-			pEntry->SktEhTblHdl.eeh_entry_index, 
+		if (cdx_ehash_delete_entry(pEntry->SktEhTblHdl.td,
+			pEntry->SktEhTblHdl.eeh_entry_index,
 			pEntry->SktEhTblHdl.eeh_entry_handle)) {
 			DPA_ERROR("%s(%d)::unable to remove entry from hash table\n",
 					__FUNCTION__, __LINE__);
 		}
-		/* free table entry */
-		ExternalHashTableEntryFree(pEntry->SktEhTblHdl.eeh_entry_handle);
-		DPA_INFO("%s()::%d Successfully deleted extended hash table key and entry:\n", 
+		DPA_INFO("%s()::%d Successfully deleted extended hash table key and entry:\n",
 							__func__, __LINE__);
 	}
 #endif/*endif for VOIP_PRIORITY_SLOW_PATH_FRAME_QUEUES */


### PR DESCRIPTION
## Behavior:
Under heavy sustained traffic, sometimes the router would panic and
crash.

## Remedy:
Identified how the hardware-offload cleanup path was handled in the
Linux ASK, and ported over for this fix.

## Result:
Tested and stable under moderate load testing, but I don't have heavy
multi-gigabit traffic available on my current router test setup.
Please try to overload it and break it. Report back if it crashes.

Linked PR (opnsense-src): we-are-mono/opnsense-src#10